### PR TITLE
Fix alpha blending.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ particularly poorly represented in the ANSI colour pallette.
 # Installing
 
 * Install Rust & Cargo: https://www.rust-lang.org/downloads.html
-* `cargo install --git https://github.com/hopey-dishwasher/termpix` (see `cargo install` options for e.g. install location customisation)
+* `cargo install --git https://github.com/fimkap/termpix` (see `cargo install` options for e.g. install location customisation)
+Use https://github.com/hopey-dishwasher/termpix for the original project.
 
 # License
 Apache 2.0 license

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,9 +75,9 @@ fn find_colour_index(pixel: &[u8]) -> u8 {
 
 fn blend_alpha(pixel: &mut image::Rgba<u8>) {
     let alpha = pixel[3] as i32 as f32/255.0;
-    pixel[0] = (alpha*(pixel[0] as i32 as f32) + (1.0 - alpha)*255.0) as u8;
-    pixel[1] = (alpha*(pixel[1] as i32 as f32) + (1.0 - alpha)*255.0) as u8;
-    pixel[2] = (alpha*(pixel[2] as i32 as f32) + (1.0 - alpha)*255.0) as u8;
+    pixel[0] = (alpha*(pixel[0] as i32 as f32) + (1.0 - alpha)*38.0) as u8;
+    pixel[1] = (alpha*(pixel[1] as i32 as f32) + (1.0 - alpha)*38.0) as u8;
+    pixel[2] = (alpha*(pixel[2] as i32 as f32) + (1.0 - alpha)*38.0) as u8;
 }
 
 static ANSI_COLOURS: [[i32; 3]; 256] = [


### PR DESCRIPTION
I have added alpha blending to both true and ANSI color mode. First of all, it fixes an artefact issue with some PNG images (probably it was caused by displaying pixels with alpha value 0). Second, the different level of transparency is supported. The alpha blending is done with white background as most of viewers do.